### PR TITLE
fix: randomize PIN digit start values to prevent side-channel attack

### DIFF
--- a/snsd/200_ui.ino
+++ b/snsd/200_ui.ino
@@ -145,7 +145,7 @@ void displayLoginScreen() {
   const int pinLength = 8;
   String enteredPin = "";
 
-  int currentDigit = 0;
+  int currentDigit = esp_random() % 10;
   unsigned long lastButtonPressTime = 0;
 
   // Initialize failed attempt count
@@ -199,6 +199,7 @@ void displayLoginScreen() {
       } else if (buttonNumber == "1" && buttonState == "1") { // Confirm digit or submit
         if (enteredPin.length() < pinLength) {
           enteredPin += String(currentDigit); // Confirm the current digit
+          currentDigit = esp_random() % 10;
 
           if (enteredPin.length() == pinLength) {
             if (enteredPin == correctPin) {
@@ -218,7 +219,7 @@ void displayLoginScreen() {
                 int attemptsLeft = maxAttempts - global.pinAttempts;
                 showMessage("PIN Denied", String(attemptsLeft) + " Attempts Left");
                 enteredPin = ""; // Reset the entered PIN
-                currentDigit = 0;
+                currentDigit = esp_random() % 10;
 
                 // Full screen clear
                 tft.fillScreen(global.backgroundColor);
@@ -237,7 +238,7 @@ void displaySetPinScreen() {
 
   const int pinLength = 8;
   String newPin = "";
-  int currentDigit = 0;
+  int currentDigit = esp_random() % 10;
 
   unsigned long lastButtonPressTime = 0;
 
@@ -289,6 +290,7 @@ void displaySetPinScreen() {
       } else if (buttonNumber == "1" && buttonState == "1") { // Confirm digit or complete PIN
         if (newPin.length() < pinLength) {
           newPin += String(currentDigit); // Add the current digit to the PIN
+          currentDigit = esp_random() % 10;
 
           if (newPin.length() == pinLength) {
             // PIN entry completed

--- a/snsd/400_helpers.ino
+++ b/snsd/400_helpers.ino
@@ -122,7 +122,7 @@ void generateNewKeyHex(char *buffer) {
 
 void generateRandomIV(uint8_t *iv, int length) {
     for (int i = 0; i < length; i++) {
-        iv[i] = random(0, 256);
+        iv[i] = esp_random() & 0xFF;
     }
 }
 


### PR DESCRIPTION
## Summary

- Randomize the starting digit for each PIN position using ESP32 hardware RNG (`esp_random()`), preventing click-counting side-channel attacks
- Randomize digit after each confirmation so consecutive positions are also unpredictable
- Replace software PRNG (`random()`) with hardware RNG (`esp_random()`) for AES-CBC IV generation

## Problem

Both `displayLoginScreen()` and `displaySetPinScreen()` initialize `currentDigit` to `0`, and carry over the previous value after each digit confirmation. An attacker who can hear or observe button click counts can trivially reconstruct the full PIN.

## Changes

**`snsd/200_ui.ino`**
- `displayLoginScreen()`: init `currentDigit` with `esp_random() % 10`; re-randomize after each digit confirm and on PIN failure reset
- `displaySetPinScreen()`: same treatment

**`snsd/400_helpers.ino`**
- `generateRandomIV()`: replace `random(0, 256)` (seeded software PRNG) with `esp_random() & 0xFF` (hardware RNG), consistent with `generateNewKeyHex()`

## Checks

- [x] Verified on LilyGo T-Display (ESP32-D0WDQ6-V3): PIN entry screen starts at random digit
- [x] Each subsequent digit position starts at a new random value
- [x] PIN failure reset also randomizes the starting digit
- [x] PIN set screen has the same randomization behavior
- [x] Correct PIN still unlocks the device